### PR TITLE
Remove malloc.h includes

### DIFF
--- a/smarc/multi_stage.c
+++ b/smarc/multi_stage.c
@@ -24,7 +24,6 @@
 
 
 #include "multi_stage.h"
-#include "malloc.h"
 #include "string.h"
 #include "stdlib.h"
 #include "stdio.h"

--- a/smarc/polyfilt.c
+++ b/smarc/polyfilt.c
@@ -26,7 +26,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <malloc.h>
 #include <string.h>
 
 void polyfiltLM(struct PSFilter* pfilt, struct PSState* pstate,

--- a/smarc/remez_lp.c
+++ b/smarc/remez_lp.c
@@ -34,7 +34,6 @@
 
 #include "remez_lp.h"
 #include <math.h>
-#include <malloc.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/smarc/smarc.c
+++ b/smarc/smarc.c
@@ -27,7 +27,6 @@
 #include "multi_stage.h"
 #include "polyfilt.h"
 #include <stdio.h>
-#include <malloc.h>
 #include <string.h>
 #include <math.h>
 

--- a/smarc/stage_impl.c
+++ b/smarc/stage_impl.c
@@ -30,7 +30,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
-#include "malloc.h"
 
 #include "remez_lp.h"
 


### PR DESCRIPTION
Including `malloc.h` is not necessary and non-standard - `stdlib.h` should be used instead.