### PR TITLE
Explicitly enable C99

### DIFF
--- a/xdf.pro
+++ b/xdf.pro
@@ -4,6 +4,8 @@ TARGET = xdf
 TEMPLATE = lib
 CONFIG += staticlib c++11
 
+QMAKE_CFLAGS += -std=c99
+
 SOURCES += xdf.cpp \
     smarc/filtering.c \
     smarc/multi_stage.c \


### PR DESCRIPTION
On some older gcc versions, C99 is not enabled by default. This flag fixes this e.g. on Debian 8.