### PR TITLE
Add minimum macOS deployment target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 
 project(libxdf)
 
@@ -23,7 +24,6 @@ set(SOURCES
 )
 
 add_library(xdf-static STATIC ${SOURCES})
-
 add_library(xdf-shared SHARED ${SOURCES})
 
 set_property(TARGET xdf-static xdf-shared PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
This is necessary to avoid warnings when linking to objects that were built with older versions of the macOS SDK. I've set it to 10.9 just like in SigViewer.