### PR TITLE
Stability improvements

### DIFF
--- a/xdf.cpp
+++ b/xdf.cpp
@@ -612,7 +612,7 @@ void Xdf::syncTimeStamps()
                 }
             }
 
-            elem.first.second += this->streams[elem.second].clock_values[k]; // apply the last offset value to the timestamp; if there hasn't yet been an ofset value take the first recorded one
+            elem.first.second += this->streams[elem.second].clock_values[k]; // apply the last offset value to the timestamp; if there hasn't yet been an offset value take the first recorded one
         }
     }
 

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -612,10 +612,7 @@ void Xdf::syncTimeStamps()
                 }
             }
 
-            if (this->streams[elem.second].clock_times[k] < elem.first.second)
-            {
-                elem.first.second += this->streams[elem.second].clock_values[k];
-            }
+            elem.first.second += this->streams[elem.second].clock_values[k]; // apply the last offset value to the timestamp; if there hasn't yet been an ofset value take the first recorded one
         }
     }
 
@@ -833,14 +830,14 @@ void Xdf::findMajSR()
     }
 
     if(srateMap.size() > 0){
-    //search the srateMap to see which sample rate has the most channels
-    int index (std::distance(srateMap.begin(),
-                             std::max_element(srateMap.begin(),srateMap.end(),
-                                            [] (const std::pair<sampRate, numChannel> &largest,
-                                            const std::pair<sampRate, numChannel> &first)
-                                            { return largest.second < first.second; })));
+        //search the srateMap to see which sample rate has the most channels
+        int index (std::distance(srateMap.begin(),
+                                 std::max_element(srateMap.begin(),srateMap.end(),
+                                                [] (const std::pair<sampRate, numChannel> &largest,
+                                                const std::pair<sampRate, numChannel> &first)
+                                                { return largest.second < first.second; })));
 
-    majSR = srateMap[index].first; //the sample rate that has the most channels
+        majSR = srateMap[index].first; //the sample rate that has the most channels
     } else {
         majSR = 0; //if there are no streams with a fixed sample reate
     }

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -832,6 +832,7 @@ void Xdf::findMajSR()
         }
     }
 
+    if(srateMap.size() > 0){
     //search the srateMap to see which sample rate has the most channels
     int index (std::distance(srateMap.begin(),
                              std::max_element(srateMap.begin(),srateMap.end(),
@@ -840,6 +841,9 @@ void Xdf::findMajSR()
                                             { return largest.second < first.second; })));
 
     majSR = srateMap[index].first; //the sample rate that has the most channels
+    } else {
+        majSR = 0; //if there are no streams with a fixed sample reate
+    }
 }
 
 void Xdf::calcTotalChannel()


### PR DESCRIPTION
Hello,
I noticed that the Sigviewer is unable to open some of my XDF recordings and I found out that the crashes were caused by this library. The two commits in this pull requests should correct the two bugs I found:

1) When you are iterating over srateMap to find the sample rate with the most channels you didn’t consider that there may be recordings that only contain streams with a variable sampling rate.

2) When syncing timestamps you didn’t sync samples that occurred before the first clock offset measurement. In any case this means that there is a gap between those samples and the synced samples. Additionally, if this offset is really large the apparent recording duration can get ridiculously long.
In some cases this even lead to crashes. This is what happens in such cases: The library allocates memory for a vector which will contain the samples. To determine the vector’s size it uses the recording’s duration. In my case it tried to allocated enough memory for a 16 kHz stream whose imaginary duration was somewhat about 60 hours. Unfortunately may pc hadn’t enough memory to hold a vector of that size so the program ran out of memory.

Let me know if you are dissatisfied with my implementation or have any improvement suggestions.