### PR TITLE
Adding support for string time series - Follow up on #43

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "C_Cpp.default.compilerPath": "c:\\Qt\\Tools\\mingw730_64\\bin\\g++.exe"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.default.compilerPath": "c:\\Qt\\Tools\\mingw730_64\\bin\\g++.exe"
+}

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -309,13 +309,12 @@ int Xdf::load_xdf(std::string filename)
                         }
 
                         streams[index].last_timestamp = ts;
-                        Stream& stream = streams[index];
 
                         std::visit([&file](auto&& time_series) {
                             using T = typename std::remove_reference_t
                                 <decltype(time_series)>::value_type::value_type;
                             read_time_series<T>(file, &time_series);
-                        }, stream.time_series);
+                        }, streams[index].time_series);
                     }
                 }
                 break;

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -633,7 +633,11 @@ void Xdf::adjustTotalLength()
             stream.info.channel_format != "string")
         {
             std::visit([this](auto&& time_series) {
-                totalLen = std::max(totalLen, time_series.front().size());
+                const size_t row_length = time_series.front().size();
+                if (totalLen < row_length)
+                {
+                    totalLen = row_length;
+                }
             }, stream.time_series);
         }
     }

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -63,7 +63,7 @@ template <typename T>
  * \param file is the XDF file that is being loaded in the type of `std::ifstream`.
  * \return The length of the upcoming chunk (in bytes).
  */
-uint64_t read_length(std::istream& is)
+[[nodiscard]] uint64_t read_length(std::istream& is)
 {
     switch (const auto bytes = read_bin<uint8_t>(is); bytes)
     {
@@ -100,10 +100,6 @@ void read_time_series(std::istream& is, std::vector<std::vector<T>>* time_series
 }
 
 } // namespace
-
-Xdf::Xdf()
-{
-}
 
 int Xdf::load_xdf(std::string filename)
 {
@@ -723,7 +719,6 @@ void Xdf::loadSampleRateSet()
         }
     }
 }
-
 
 void Xdf::detrend()
 {

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -752,10 +752,12 @@ void Xdf::adjustTotalLength()
 {
     for (auto const& stream : streams)
     {
-        if (!stream.time_series.empty())
+        if (stream.time_series.index() != std::variant_npos &&
+            stream.info.channel_format.compare("string") != 0)
         {
-            if (totalLen < stream.time_series.front().size())
-                totalLen = stream.time_series.front().size();
+            std::visit([this](auto&& time_series) {
+                totalLen = std::max(totalLen, time_series.front().size());
+            }, stream.time_series);
         }
     }
 }
@@ -953,7 +955,7 @@ void Xdf::createLabels()
         }
         else
         {
-            for (size_t ch = 0; ch < streams[st].time_series.size(); ch++)
+            for (size_t ch = 0; ch < streams[st].info.channel_count; ch++)
             {
                 // +1 for 1 based numbers; for user convenience only. The internal computation is still 0 based
                 std::string label = "Stream " + std::to_string(st + 1) +

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -141,14 +141,14 @@ int Xdf::load_xdf(std::string filename)
             case 2: //read [StreamHeader] chunk
                 {
                     //read [StreamID]
-                    const auto streamID = read_bin<uint32_t>(file);
+                    const auto stream_id = read_bin<uint32_t>(file);
                     int index;
 
-                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), streamID)};
+                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), stream_id)};
                     if (it == idmap.end())
                     {
                         index = idmap.size();
-                        idmap.emplace_back(streamID);
+                        idmap.emplace_back(stream_id);
                         streams.emplace_back();
                     }
                     else
@@ -231,13 +231,13 @@ int Xdf::load_xdf(std::string filename)
             case 3: //read [Samples] chunk
                 {
                     //read [StreamID]
-                    const auto streamID = read_bin<uint32_t>(file);
+                    const auto stream_id = read_bin<uint32_t>(file);
                     int index;
-                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), streamID)};
+                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), stream_id)};
                     if (it == idmap.end())
                     {
                         index = idmap.size();
-                        idmap.emplace_back(streamID);
+                        idmap.emplace_back(stream_id);
                         streams.emplace_back();
                     }
                     else
@@ -290,13 +290,13 @@ int Xdf::load_xdf(std::string filename)
                 break;
             case 4: //read [ClockOffset] chunk
                 {
-                    const auto streamID = read_bin<uint32_t>(file);
+                    const auto stream_id = read_bin<uint32_t>(file);
                     int index;
-                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), streamID)};
+                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), stream_id)};
                     if (it == idmap.end())
                     {
                         index = idmap.size();
-                        idmap.emplace_back(streamID);
+                        idmap.emplace_back(stream_id);
                         streams.emplace_back();
                     }
                     else
@@ -314,13 +314,13 @@ int Xdf::load_xdf(std::string filename)
                     pugi::xml_document doc;
 
                     //read [StreamID]
-                    const auto streamID = read_bin<uint32_t>(file);
+                    const auto stream_id = read_bin<uint32_t>(file);
                     int index;
-                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), streamID)};
+                    std::vector<int>::iterator it{std::find(idmap.begin(), idmap.end(), stream_id)};
                     if (it == idmap.end())
                     {
                         index = idmap.size();
-                        idmap.emplace_back(streamID);
+                        idmap.emplace_back(stream_id);
                         streams.emplace_back();
                     }
                     else

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -12,7 +12,7 @@
 //GNU General Public License for more details.
 
 //You should have received a copy of the GNU General Public License
-//along with this program.  If not, see <http: /www.gnu.org/licenses />.
+//along with this program. If not, see <http://www.gnu.org/licenses/>.
 //If you have questions, contact author at yida.lin@outlook.com
 
 
@@ -20,15 +20,15 @@
 
 #include <iostream>
 #include <fstream>
-#include "pugixml.hpp"  //pugi XML parser
 #include <sstream>
 #include <algorithm>
-#include "smarc/smarc.h"      //resampling library
 #include <time.h>       /* clock_t, clock, CLOCKS_PER_SEC */
 #include <numeric>      //std::accumulate
-#include <functional>   // bind2nd
 #include <cmath>
 #include <variant>
+
+#include "pugixml.hpp"      //pugi XML parser
+#include "smarc/smarc.h"    //resampling library
 
 namespace xdf {
 namespace {

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -226,6 +226,10 @@ int Xdf::load_xdf(std::string filename)
                         stream.time_series = std::vector<std::vector<int64_t>>(
                                 channel_count);
                     }
+                    else {
+                        throw std::runtime_error("Unexpected channel format: "
+                                                 + std::string(channel_format));
+                    }
                 }
                 break;
             case 3: //read [Samples] chunk

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -274,22 +274,12 @@ int Xdf::load_xdf(std::string filename)
                     for (size_t i = 0; i < num_samples; i++)
                     {
                         //read or deduce time stamp
-                        const auto tsBytes = read_bin<uint8_t>(file);
-
-                        double ts; //temporary time stamp
-
-                        if (tsBytes == 8)
-                        {
-                            ts = read_bin<double>(file);
-                            stream.time_stamps.emplace_back(ts);
-                        }
-                        else
-                        {
-                            ts = stream.last_timestamp + stream.sampling_interval;
-                            stream.time_stamps.emplace_back(ts);
-                        }
-
-                        stream.last_timestamp = ts;
+                        const auto time_stamp_bytes = read_bin<uint8_t>(file);
+                        const double time_stamp = time_stamp_bytes == 8
+                            ? read_bin<double>(file)
+                            : stream.last_timestamp + stream.sampling_interval;
+                        stream.time_stamps.push_back(time_stamp);
+                        stream.last_timestamp = time_stamp;
 
                         std::visit([&file](auto&& time_series) {
                             using T = typename std::decay_t<decltype(time_series)>

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -55,9 +55,9 @@ T read_bin(std::istream& is)
 
 template <typename T>
 void read_time_series(std::istream& is, std::vector<std::vector<T>>* time_series) {
-    for (size_t v = 0; v < time_series->size(); ++v)
+    for (std::vector<T>& row : *time_series)
     {
-        (*time_series)[v].push_back(std::move(read_bin<T>(is)));
+        row.push_back(std::move(read_bin<T>(is)));
     }
 }
 

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -78,6 +78,13 @@ template <typename T>
     }
 }
 
+/*!
+ * \brief Reads N samples from `istream` and appends to each row of
+ * `time_series`, where N is the number of channels in `time_series`.
+ *
+ * \param istream the input stream.
+ * \param time_series the 2D vector to append to.
+ */
 template <typename T>
 void read_time_series(std::istream& istream,
                       std::vector<std::vector<T>>* time_series) {

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -640,11 +640,7 @@ void Xdf::adjustTotalLength()
             stream.info.channel_format != "string")
         {
             std::visit([this](auto&& time_series) {
-                const size_t row_length = time_series.front().size();
-                if (totalLen < row_length)
-                {
-                    totalLen = row_length;
-                }
+                totalLen = std::max(totalLen, time_series.front().size());
             }, stream.time_series);
         }
     }

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -57,7 +57,7 @@ template <typename T>
 void read_time_series(std::istream& is, std::vector<std::vector<T>>* time_series) {
     for (size_t v = 0; v < time_series->size(); ++v)
     {
-        (*time_series)[v].push_back(read_bin<T>(is));
+        (*time_series)[v].push_back(std::move(read_bin<T>(is)));
     }
 }
 

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -232,37 +232,38 @@ int Xdf::load_xdf(std::string filename)
                     if (const std::string_view channel_format = stream.info.channel_format;
                             channel_format == "string")
                     {
-                        stream.time_series = std::vector<std::vector<std::string>>(
+                        stream.time_series.emplace<std::vector<std::vector<std::string>>>(
                             channel_count);
                     }
                     else if (channel_format == "float32")
                     {
-                        stream.time_series = std::vector<std::vector<float>>(
+                        stream.time_series.emplace<std::vector<std::vector<float>>>(
                             channel_count);
                     }
                     else if (channel_format == "double64")
                     {
-                        stream.time_series = std::vector<std::vector<double>>(
+                        stream.time_series.emplace<std::vector<std::vector<double>>>(
                             channel_count);
                     }
                     else if (channel_format == "int8_t")
                     {
-                        stream.time_series = std::vector<std::vector<int8_t>>(
+                        stream.time_series.emplace<std::vector<std::vector<int8_t>>>(
                             channel_count);
                     }
                     else if (channel_format == "int16_t")
                     {
-                        stream.time_series = std::vector<std::vector<int16_t>>(
+                        stream.time_series.emplace<std::vector<std::vector<int16_t>>>(
                             channel_count);
                     }
                     else if (channel_format == "int32_t")
                     {
-                        stream.time_series = std::vector<std::vector<int>>(channel_count);
+                        stream.time_series.emplace<std::vector<std::vector<int>>>(
+                            channel_count);
                     }
                     else if (channel_format == "int64_t")
                     {
-                        stream.time_series = std::vector<std::vector<int64_t>>(
-                                channel_count);
+                        stream.time_series.emplace<std::vector<std::vector<int64_t>>>(
+                            channel_count);
                     }
                     else {
                         throw std::runtime_error("Unexpected channel format: "

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -261,11 +261,11 @@ int Xdf::load_xdf(std::string filename)
                     //read [StreamID]
                     const auto stream_id = read_bin<uint32_t>(file);
                     //read [NumSampleBytes], [NumSamples]
-                    const uint64_t numSamp = read_length(file);
+                    const uint64_t num_samples = read_length(file);
                     Stream& stream = streams[stream_id];
 
                     //for each sample
-                    for (size_t i = 0; i < numSamp; i++)
+                    for (size_t i = 0; i < num_samples; i++)
                     {
                         //read or deduce time stamp
                         const auto tsBytes = read_bin<uint8_t>(file);

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -714,9 +714,10 @@ void Xdf::calcTotalChannel()
     //calculating total channel count, and indexing them onto streamMap
     for (size_t c = 0; c < streams.size(); c++)
     {
-        if (!streams[c].time_series.empty())
+        if (streams[c].time_series.index() != std::variant_npos &&
+            streams[c].info.channel_format.compare("string") != 0)
         {
-            totalCh += streams[c].info.channel_count;
+            numerical_channel_count_ += streams[c].info.channel_count;
 
             for (int i = 0; i < streams[c].info.channel_count; i++)
                 streamMap.emplace_back(c);

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -472,7 +472,7 @@ void Xdf::resample(int userSrate)
                     // Only replace numeric values
                     if constexpr (std::is_arithmetic_v<T>)
                     {
-                        for (auto& val : row)
+                        for (T& val : row)
                         {
                             val = static_cast<T>(outbuf[read++]);
                         }
@@ -486,7 +486,7 @@ void Xdf::resample(int userSrate)
                     // Only replace numeric values
                     if constexpr (std::is_arithmetic_v<T>)
                     {
-                        for (auto& val : row)
+                        for (T& val : row)
                         {
                             val = static_cast<T>(outbuf[read++]);
                         }

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -34,13 +34,12 @@ namespace xdf {
 namespace {
 
 /*!
- * \brief Read a binary scalar variable from an input stream.
+ * \brief Reads a binary scalar variable from an input stream.
  *
  * read_bin is a convenience wrapper for the common
  * file.read((char*) var, sizeof(var))
  * operation. Examples:
- * double foo = read_bin<double>(file); // use return value
- * read_bin(file, &foo); // read directly into foo
+ * double foo = read_bin<double>(file);
  * \param is an input stream to read from
  * \param obj pointer to a variable to load the data into or nullptr
  * \return the read data
@@ -60,7 +59,7 @@ template <typename T>
  * While loading XDF file there are 2 cases where this function will be
  * needed. One is to get the length of each chunk, one is to get the
  * number of samples when loading the time series (Chunk tag 3).
- * \param file is the XDF file that is being loaded in the type of `std::ifstream`.
+ * \param file is the XDF file that is being loaded.
  * \return The length of the upcoming chunk (in bytes).
  */
 [[nodiscard]] uint64_t read_length(std::istream& istream)

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -269,21 +269,21 @@ int Xdf::load_xdf(std::string filename)
                         streams[index].last_timestamp = ts;
                         Stream& stream = streams[index];
 
-                        std::visit([this, &file](auto&& arg) {
-                            using T = typename std::remove_reference_t<decltype(arg)>
-                                ::value_type::value_type;
+                        std::visit([this, &file](auto&& time_series) {
+                            using T = typename std::remove_reference_t
+                                <decltype(time_series)>::value_type::value_type;
                             if constexpr (std::is_same_v<T, std::string>) {
-                                for (int v = 0; v < arg.size(); ++v)
+                                for (std::vector<std::string>& row : time_series)
                                 {
-                                    const auto length = Xdf::readLength(file);
+                                    const uint64_t length = Xdf::readLength(file);
                                     char* buffer = new char[length + 1];
                                     file.read(buffer, length);
                                     buffer[length] = '\0';
-                                    arg[v].emplace_back(buffer);
+                                    row.emplace_back(buffer);
                                     delete[] buffer;
                                 }
                             } else {
-                                read_time_series(file, &arg);
+                                read_time_series(file, &time_series);
                             }
                         }, stream.time_series);
                     }

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -352,8 +352,6 @@ int Xdf::load_xdf(std::string filename)
 
         getHighestSampleRate();
 
-        loadSampleRateSet();
-
         calcEffectiveSrate();
 
         //loading finishes, close file
@@ -642,17 +640,6 @@ void Xdf::getHighestSampleRate()
     {
         if (stream.info.nominal_srate > maxSR)
             maxSR = stream.info.nominal_srate;
-    }
-}
-
-void Xdf::loadSampleRateSet()
-{
-    for (const auto& [stream_id, stream] : streams)
-    {
-        if (stream.info.channel_format != "string")
-        {
-            sample_rates.insert(stream.info.nominal_srate);
-        }
     }
 }
 

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -190,36 +190,36 @@ int Xdf::load_xdf(std::string filename)
                     Stream& stream = streams[index];
                     const int channel_count = stream.info.channel_count;
                     if (const std::string_view channel_format = stream.info.channel_format;
-                            channel_format.compare("string") == 0)
+                            channel_format == "string")
                     {
                         stream.time_series = std::vector<std::vector<std::string>>(
                             channel_count);
                     }
-                    else if (channel_format.compare("float32") == 0)
+                    else if (channel_format == "float32")
                     {
                         stream.time_series = std::vector<std::vector<float>>(
                             channel_count);
                     }
-                    else if (channel_format.compare("double64") == 0)
+                    else if (channel_format == "double64")
                     {
                         stream.time_series = std::vector<std::vector<double>>(
                             channel_count);
                     }
-                    else if (channel_format.compare("int8_t") == 0)
+                    else if (channel_format == "int8_t")
                     {
                         stream.time_series = std::vector<std::vector<int8_t>>(
                             channel_count);
                     }
-                    else if (channel_format.compare("int16_t") == 0)
+                    else if (channel_format == "int16_t")
                     {
                         stream.time_series = std::vector<std::vector<int16_t>>(
                             channel_count);
                     }
-                    else if (channel_format.compare("int32_t") == 0)
+                    else if (channel_format == "int32_t")
                     {
                         stream.time_series = std::vector<std::vector<int>>(channel_count);
                     }
-                    else if (channel_format.compare("int64_t") == 0)
+                    else if (channel_format == "int64_t")
                     {
                         stream.time_series = std::vector<std::vector<int64_t>>(
                                 channel_count);
@@ -447,7 +447,7 @@ void Xdf::syncTimeStamps()
     // Update first and last time stamps in stream footer
     for (size_t k = 0; k < this->streams.size(); k++)
     {
-        if (streams[k].info.channel_format.compare("string") == 0)
+        if (streams[k].info.channel_format == "string")
         {
             double min = NAN;
             double max = NAN;
@@ -493,7 +493,7 @@ void Xdf::resample(int userSrate)
     for (Stream& stream : streams)
     {
         if (stream.time_series.index() != std::variant_npos &&
-            !stream.info.channel_format.compare("string") &&
+            stream.info.channel_format != "string" &&
             stream.info.nominal_srate != userSrate &&
             stream.info.nominal_srate != 0)
         {
@@ -702,7 +702,7 @@ void Xdf::calcTotalChannel()
     for (size_t c = 0; c < streams.size(); c++)
     {
         if (streams[c].time_series.index() != std::variant_npos &&
-            streams[c].info.channel_format.compare("string") != 0)
+            streams[c].info.channel_format != "string")
         {
             numerical_channel_count_ += streams[c].info.channel_count;
 
@@ -740,7 +740,7 @@ void Xdf::adjustTotalLength()
     for (auto const& stream : streams)
     {
         if (stream.time_series.index() != std::variant_npos &&
-            stream.info.channel_format.compare("string") != 0)
+            stream.info.channel_format != "string")
         {
             std::visit([this](auto&& time_series) {
                 totalLen = std::max(totalLen, time_series.front().size());

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -312,8 +312,8 @@ int Xdf::load_xdf(std::string filename)
                         streams[index].last_timestamp = ts;
 
                         std::visit([&file](auto&& time_series) {
-                            using T = typename std::remove_reference_t
-                                <decltype(time_series)>::value_type::value_type;
+                            using T = typename std::decay_t<decltype(time_series)>
+                                ::value_type::value_type;
                             read_time_series<T>(file, &time_series);
                         }, streams[index].time_series);
                     }
@@ -545,7 +545,7 @@ void Xdf::resample(int userSrate)
             struct PState* pstate = smarc_init_pstate(pfilt);
 
             std::visit([&pfilt, &pstate](auto&& time_series) {
-                using T = typename std::remove_reference_t<decltype(time_series)>
+                using T = typename std::decay_t<decltype(time_series)>
                     ::value_type::value_type;
                 for (std::vector<T>& row : time_series)
                 {
@@ -778,7 +778,7 @@ void Xdf::detrend()
     for (Stream &stream : streams)
     {
         std::visit([this](auto&& time_series) {
-            using T = typename std::remove_reference_t<decltype(time_series)>
+            using T = typename std::decay_t<decltype(time_series)>
                 ::value_type::value_type;
             if constexpr (std::is_arithmetic_v<T>) {
                 for (auto& row : time_series)

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -46,7 +46,7 @@ namespace {
  * \return the read data
  */
 template <typename T>
-T read_bin(std::istream& is)
+[[nodiscard]] T read_bin(std::istream& is)
 {
     T obj;
     is.read(reinterpret_cast<char*>(&obj), sizeof(T));

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -156,6 +156,36 @@ int Xdf::load_xdf(std::string filename)
                     else
                         streams[index].sampling_interval = 0;
 
+                    Stream& stream = streams[index];
+                    const int channel_count = stream.info.channel_count;
+                    if (const std::string_view channel_format = stream.info.channel_format;
+                            channel_format.compare("string") == 0)
+                    {
+                        stream.time_series = std::vector<std::vector<std::string>>(
+                            channel_count);
+                    }
+                    else if (channel_format.compare("float32") == 0)
+                    {
+                        stream.time_series = std::vector<std::vector<float>>(
+                            channel_count);
+                    }
+                    else if (channel_format.compare("double64") == 0)
+                    {
+                        stream.time_series = std::vector<std::vector<double>>(
+                            channel_count);
+                    }
+                    else if (channel_format.compare("int8_t") == 0 ||
+                               channel_format.compare("int16_t") == 0 ||
+                               channel_format.compare("int32_t") == 0)
+                    {
+                        stream.time_series = std::vector<std::vector<int>>(channel_count);
+                    }
+                    else if (channel_format.compare("int64_t") == 0)
+                    {
+                        stream.time_series = std::vector<std::vector<int64_t>>(
+                                channel_count);
+                    }
+
                     delete[] buffer;
                 }
                 break;

--- a/xdf.h
+++ b/xdf.h
@@ -58,10 +58,12 @@ public:
     {
         //! A 2D vector which stores the time series of a stream. Each row represents a channel.
         std::variant<
+            std::vector<std::vector<int8_t>>,
+            std::vector<std::vector<int16_t>>,
             std::vector<std::vector<int>>,
+            std::vector<std::vector<int64_t>>,
             std::vector<std::vector<float>>,
             std::vector<std::vector<double>>,
-            std::vector<std::vector<int64_t>>,
             std::vector<std::vector<std::string>>> time_series;
         std::vector<double> time_stamps; /*!< A vector to store time stamps. */
         std::string streamHeader;   /*!< Raw XML of stream header chunk. */
@@ -306,21 +308,6 @@ private:
      * \return The length of the upcoming chunk (in bytes).
      */
     uint64_t readLength(std::ifstream &file);
-
-	/*!
-     * \brief Read a binary scalar variable from an input stream.
-     *
-     * readBin is a convenience wrapper for the common
-     * file.read((char*) var, sizeof(var))
-     * operation. Examples:
-     * double foo = readBin<double>(file); // use return value
-     * readBin(file, &foo); // read directly into foo
-     * \param is an input stream to read from
-     * \param obj pointer to a variable to load the data into or nullptr
-     * \return the read data
-     */
-    template<typename T> T readBin(std::istream& is, T* obj = nullptr);
- 
 };
 
 } // namespace xdf

--- a/xdf.h
+++ b/xdf.h
@@ -104,7 +104,7 @@ public:
 
     double minTS = 0;        /*!< The smallest time stamp across all streams. */
     double maxTS = 0;        /*!< The largest time stamp across all streams. */
-    size_t totalCh = 0;     /*!< The total number of channel count. */
+    size_t numerical_channel_count_ = 0;     /*!< The total number of numericla channels. */
     int majSR = 0;          /*!< The sample rate that has the most channels across all streams. */
     int maxSR = 0;          /*!< Highest sample rate across all streams. */
     std::vector<double> effectiveSampleRateVector; /*!< Effective Sample Rate of each stream. */

--- a/xdf.h
+++ b/xdf.h
@@ -55,7 +55,12 @@ public:
     struct Stream
     {
         //! A 2D vector which stores the time series of a stream. Each row represents a channel.
-        std::vector<std::vector<std::variant<int, float, double, int64_t, std::string>>> time_series;
+        std::variant<
+            std::vector<std::vector<int>>,
+            std::vector<std::vector<float>>,
+            std::vector<std::vector<double>>,
+            std::vector<std::vector<int64_t>>,
+            std::vector<std::vector<std::string>>> time_series;
         std::vector<double> time_stamps; /*!< A vector to store time stamps. */
         std::string streamHeader;   /*!< Raw XML of stream header chunk. */
         std::string streamFooter;   /*!< Raw XML of stream footer chunk. */

--- a/xdf.h
+++ b/xdf.h
@@ -96,7 +96,7 @@ public:
 
     //XDF properties=================================================================================
 
-    std::unordered_map<int, Stream> streams; /*!< A vector to store all the streams of the current XDF file. */
+    std::unordered_map<int, Stream> streams; /*!< Maps all stream IDs to streams in the XDF file. */
     float version;  /*!< The version of XDF file */
 
     uint64_t totalLen = 0;  /*!< The total length is the product of the range between the smallest

--- a/xdf.h
+++ b/xdf.h
@@ -297,17 +297,6 @@ private:
      * \sa sampleRateMap
      */
     void loadSampleRateMap();
-
-    /*!
-     * \brief This function will get the length of the upcoming chunk, or the number of samples.
-     *
-     * While loading XDF file there are 2 cases where this function will be
-     * needed. One is to get the length of each chunk, one is to get the
-     * number of samples when loading the time series (Chunk tag 3).
-     * \param file is the XDF file that is being loaded in the type of `std::ifstream`.
-     * \return The length of the upcoming chunk (in bytes).
-     */
-    uint64_t readLength(std::ifstream &file);
 };
 
 } // namespace xdf

--- a/xdf.h
+++ b/xdf.h
@@ -22,12 +22,12 @@
 #ifndef XDF_H
 #define XDF_H
 
-#include <string>
-#include <vector>
-#include <map>
-#include <unordered_set>
 #include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <variant>
+#include <vector>
 
 namespace xdf {
 
@@ -77,7 +77,7 @@ public:
             std::string type;       /*!< Type of the current stream. */
             std::string channel_format;/*!< Channel format of the current stream. */
 
-            std::vector<std::map<std::string, std::string> > channels;/*!< A vector to store the meta-data of the channels of the current stream. */
+            std::vector<std::unordered_map<std::string, std::string> > channels;/*!< A vector to store the meta-data of the channels of the current stream. */
 
             std::vector<std::pair<double, double> > clock_offsets;  /*!< A vector to store clock offsets from the ClockOffset chunk. */
 
@@ -96,7 +96,7 @@ public:
 
     //XDF properties=================================================================================
 
-    std::vector<Stream> streams; /*!< A vector to store all the streams of the current XDF file. */
+    std::unordered_map<int, Stream> streams; /*!< A vector to store all the streams of the current XDF file. */
     float version;  /*!< The version of XDF file */
 
     uint64_t totalLen = 0;  /*!< The total length is the product of the range between the smallest
@@ -104,13 +104,10 @@ public:
 
     double minTS = 0;        /*!< The smallest time stamp across all streams. */
     double maxTS = 0;        /*!< The largest time stamp across all streams. */
-    size_t numerical_channel_count_ = 0;     /*!< The total number of numerical channels. */
     int majSR = 0;          /*!< The sample rate that has the most channels across all streams. */
     int maxSR = 0;          /*!< Highest sample rate across all streams. */
     std::vector<double> effectiveSampleRateVector; /*!< Effective Sample Rate of each stream. */
     double fileEffectiveSampleRate = 0; /*!< If effective sample rates in all the streams are the same, this is the value. */
-    std::vector<int> streamMap;/*!< A vector indexes which channels belong to which stream.
-                                * The index is the same as channel number; the actual content is the stream Number */
 
     /*!
      * \brief Used as `std::vector<std::pair<std::pair<eventName, eventTimeStamp>, int> >`
@@ -229,18 +226,6 @@ private:
      * \brief calcEffectiveSrate
      */
     void calcEffectiveSrate();
-
-    /*!
-     * \brief Calculate the total channel count and store the result
-     * in `totalCh`.
-     *
-     * Channels of both regular and irregular sample rates are included.
-     * The streams with the channel format `string` are excluded, and are
-     * stored in `eventMap` instead.
-     *
-     * \sa totalCh, eventMap
-     */
-    void calcTotalChannel();
 
     /*!
      * \brief Find the sample rate that has the most channels.

--- a/xdf.h
+++ b/xdf.h
@@ -123,7 +123,6 @@ public:
     typedef double eventTimeStamp;
 
     std::vector<std::string> labels;    /*!< The vector to store descriptive labels of each channel. */
-    std::unordered_set<double> sample_rates;  /*!< The vector to store all sample rates across all the streams. */
     std::vector<float> offsets;         /*!< Offsets of each channel after using subtractMean() function */
 
     std::string fileHeader;             /*!< Raw XML of the file header. */
@@ -264,13 +263,6 @@ private:
      * \sa maxSR
      */
     void getHighestSampleRate();
-
-    /*!
-     * \brief Load every sample rate appeared in the current file into
-     * member variable `sample_rates`.
-     * \sa sampleRateSet
-     */
-    void loadSampleRateSet();
 };
 
 } // namespace xdf

--- a/xdf.h
+++ b/xdf.h
@@ -29,6 +29,8 @@
 #include <cstdint>
 #include <variant>
 
+namespace xdf {
+
 /*! \class Xdf
  *
  * Xdf class is designed to store the data of an entire XDF file.
@@ -320,5 +322,7 @@ private:
     template<typename T> T readBin(std::istream& is, T* obj = nullptr);
  
 };
+
+} // namespace xdf
 
 #endif // XDF_H

--- a/xdf.h
+++ b/xdf.h
@@ -42,7 +42,7 @@ class Xdf
 {  
 public:
     //! Default constructor with no parameter.
-    Xdf();
+    explicit Xdf() = default;
 
     //subclass for single streams
     /*! \class Stream
@@ -125,10 +125,6 @@ public:
      */
     typedef double eventTimeStamp;
 
-    // std::vector<std::pair<std::pair<eventName, eventTimeStamp>, int> > eventMap;/*!< The vector to store all the events across all streams.
-    //                                                                              * The format is <<events, timestamps>, streamNum>. */
-    // std::vector<std::string> dictionary;/*!< The vector to store unique event types with no repetitions. \sa eventMap */
-    // std::vector<uint16_t> eventType;    /*!< The vector to store events by their index in the dictionary.\sa dictionary, eventMap */
     std::vector<std::string> labels;    /*!< The vector to store descriptive labels of each channel. */
     std::unordered_set<double> sample_rates;  /*!< The vector to store all sample rates across all the streams. */
     std::vector<float> offsets;         /*!< Offsets of each channel after using subtractMean() function */

--- a/xdf.h
+++ b/xdf.h
@@ -99,7 +99,7 @@ public:
     std::unordered_map<int, Stream> streams; /*!< Maps all stream IDs to streams in the XDF file. */
     float version;  /*!< The version of XDF file */
 
-    uint64_t totalLen = 0;  /*!< The total length is the product of the range between the smallest
+    size_t totalLen = 0;  /*!< The total length is the product of the range between the smallest
                              *time stamp and the largest multiplied by the major sample rate. */
 
     double minTS = 0;        /*!< The smallest time stamp across all streams. */

--- a/xdf.h
+++ b/xdf.h
@@ -104,7 +104,7 @@ public:
 
     double minTS = 0;        /*!< The smallest time stamp across all streams. */
     double maxTS = 0;        /*!< The largest time stamp across all streams. */
-    size_t numerical_channel_count_ = 0;     /*!< The total number of numericla channels. */
+    size_t numerical_channel_count_ = 0;     /*!< The total number of numerical channels. */
     int majSR = 0;          /*!< The sample rate that has the most channels across all streams. */
     int maxSR = 0;          /*!< Highest sample rate across all streams. */
     std::vector<double> effectiveSampleRateVector; /*!< Effective Sample Rate of each stream. */

--- a/xdf.h
+++ b/xdf.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <set>
+#include <unordered_set>
 #include <cstdint>
 #include <variant>
 
@@ -125,12 +125,12 @@ public:
      */
     typedef double eventTimeStamp;
 
-    std::vector<std::pair<std::pair<eventName, eventTimeStamp>, int> > eventMap;/*!< The vector to store all the events across all streams.
-                                                                                 * The format is <<events, timestamps>, streamNum>. */
-    std::vector<std::string> dictionary;/*!< The vector to store unique event types with no repetitions. \sa eventMap */
-    std::vector<uint16_t> eventType;    /*!< The vector to store events by their index in the dictionary.\sa dictionary, eventMap */
+    // std::vector<std::pair<std::pair<eventName, eventTimeStamp>, int> > eventMap;/*!< The vector to store all the events across all streams.
+    //                                                                              * The format is <<events, timestamps>, streamNum>. */
+    // std::vector<std::string> dictionary;/*!< The vector to store unique event types with no repetitions. \sa eventMap */
+    // std::vector<uint16_t> eventType;    /*!< The vector to store events by their index in the dictionary.\sa dictionary, eventMap */
     std::vector<std::string> labels;    /*!< The vector to store descriptive labels of each channel. */
-    std::set<double> sampleRateMap;  /*!< The vector to store all sample rates across all the streams. */
+    std::unordered_set<double> sample_rates;  /*!< The vector to store all sample rates across all the streams. */
     std::vector<float> offsets;         /*!< Offsets of each channel after using subtractMean() function */
 
     std::string fileHeader;             /*!< Raw XML of the file header. */
@@ -285,18 +285,11 @@ private:
     void getHighestSampleRate();
 
     /*!
-     * \brief Copy all unique types of events from _eventMap_ to
-     * _dictionary_ with no repeats.
-     * \sa dictionary, eventMap
-     */
-    void loadDictionary();
-
-    /*!
      * \brief Load every sample rate appeared in the current file into
-     * member variable `sampleRateMap`.
-     * \sa sampleRateMap
+     * member variable `sample_rates`.
+     * \sa sampleRateSet
      */
-    void loadSampleRateMap();
+    void loadSampleRateSet();
 };
 
 } // namespace xdf


### PR DESCRIPTION
Follow up on #43.

As discussed:

- Removing certain outdated data structures like `eventMap` and use `time_series` to handle all types of data.
- As all the data points within a single stream is monotonous, use `std::variant<std::vector<...>>` instead of `std::vector<std::variant<...>>` to be more efficient (avoiding redundant `std::visit`)
- Other clean ups