### PR TITLE
Ignore empty samples in string streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] · YYYY-MM-DD
+### 🔧 Fixed
+- Ignore empty samples in regular-rate marker streams ([#61](https://github.com/xdf-modules/libxdf/pull/61) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.0.0] · 2026-07-05
 ### 🔧 Fixed

--- a/xdf.cpp
+++ b/xdf.cpp
@@ -422,7 +422,13 @@ int Xdf::load_xdf(std::string filename)
                             char* buffer = new char[length + 1];
                             file.read(buffer, length);
                             buffer[length] = '\0';
-                            eventMap.emplace_back(std::make_pair(buffer, ts), index);
+                            // Regular-rate marker streams emit a sample on every
+                            // tick, using an empty string as a "nothing happened"
+                            // placeholder; only non-empty samples are markers.
+                            // Irregular streams only emit samples when something
+                            // actually happens, so every sample is kept.
+                            if (streams[index].info.nominal_srate == 0 || length > 0)
+                                eventMap.emplace_back(std::make_pair(buffer, ts), index);
                             delete[] buffer;
                         }
                         streams[index].last_timestamp = ts;


### PR DESCRIPTION
Otherwise, even empty samples are converted to events/annotations.