### PR TITLE
Fix pugixml dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.3] · YYYY-MM-DD
+### 🔧 Fixed
+- `libxdfConfig.cmake` no longer unconditionally requires system `pugixml` for library consumers ([Clemens Brunner](https://github.com/cbrnr))
+
 ## [1.0.2] · 2026-07-07
 ### ✨ Added
 - Add `libxdfConfigVersion.cmake` to allow CMake's `find_package()` to check for compatible versions ([#62](https://github.com/xdf-modules/libxdf/pull/62) by [Clemens Brunner](https://github.com/cbrnr))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [1.0.3] · YYYY-MM-DD
 ### 🔧 Fixed
-- `libxdfConfig.cmake` no longer unconditionally requires system `pugixml` for library consumers ([Clemens Brunner](https://github.com/cbrnr))
+- `libxdfConfig.cmake` no longer unconditionally requires system `pugixml` for library consumers ([#64](https://github.com/xdf-modules/libxdf/pull/64) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.0.2] · 2026-07-07
 ### ✨ Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 11)
 
 project(
     libxdf
-    VERSION 1.0.2
+    VERSION 1.0.3
     DESCRIPTION "C++ library for loading multimodal, multi-rate signals stored in XDF files"
     HOMEPAGE_URL https://xdf-modules.github.io/libxdf/
 )
@@ -34,10 +34,15 @@ find_package(pugixml 1.9 QUIET)
 if(TARGET pugixml AND NOT XDF_NO_SYSTEM_PUGIXML)
     message(STATUS "Using system pugixml")
     target_link_libraries(xdf PRIVATE pugixml)
+    # Consumers of the installed xdf target need to find_dependency(pugixml)
+    # too (see libxdfConfig.cmake.in), but only in this branch: the bundled
+    # copy below is compiled directly into libxdf and needs nothing external.
+    set(XDF_PUGIXML_FIND_DEPENDENCY "find_dependency(pugixml)")
 else()
     message(STATUS "Using bundled pugixml")
     target_sources(xdf PRIVATE pugixml/pugixml.cpp)
     target_include_directories(xdf PRIVATE pugixml)
+    set(XDF_PUGIXML_FIND_DEPENDENCY "")
 endif()
 
 target_compile_features(xdf PUBLIC cxx_std_20)

--- a/libxdfConfig.cmake.in
+++ b/libxdfConfig.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(pugixml)
+@XDF_PUGIXML_FIND_DEPENDENCY@
 
 if(NOT TARGET XDF::xdf)
     include("${CMAKE_CURRENT_LIST_DIR}/libxdfTargets.cmake")


### PR DESCRIPTION
`libxdfConfig.cmake` no longer unconditionally requires system `pugixml` for library consumers.